### PR TITLE
Only set art when it exists

### DIFF
--- a/service.py
+++ b/service.py
@@ -49,6 +49,17 @@ def getParams():
     return cleanedparams
 
 
+def getPlayItemFromVideo(video):
+    debug(video)
+    url = video['url']
+    thumbnail = video['thumbnail']
+    title = video['title']
+    play_item = xbmcgui.ListItem(title, path=url)
+    play_item.setInfo(type='Video', infoLabels={'Title': title})
+    play_item.setArt({'thumb': thumbnail})
+    return play_item
+
+
 ydl_opts = {
     'format': 'best'
 }
@@ -62,30 +73,16 @@ ydl.add_default_info_extractors()
 with ydl:
     showInfoNotification("resolving stream(s)")
     result = ydl.extract_info(url, download=False)
+
 if 'entries' in result:
     # Playlist
     pl = xbmc.PlayList(1)
     pl.clear()
     for video in result['entries']:
-        debug(video)
-        url = video['url']
-        thumbnail = video['thumbnail']
-        title = video['title']
-        play_item = xbmcgui.ListItem(title, path=url)
-        play_item.setInfo(type='Video', infoLabels={'Title': title})
-        play_item.setArt({'thumb': thumbnail})
-        xbmc.PlayList(1).add(url, play_item)
+        xbmc.PlayList(1).add(url, getPlayItemFromVideo(video))
     xbmc.Player().play(pl)
     showInfoNotification("playing playlist " + result['title'])
 else:
-    # Just a video
-    debug(result)
-    title = result['title']
-    thumbnail = result['thumbnail']
-    url = result['url']
-    play_item = xbmcgui.ListItem(title, path=url)
-    play_item.setInfo(type='Video', infoLabels={'Title': title})
-    play_item.setArt({'thumb': thumbnail})
-    # Pass the item to the Kodi player.
-    showInfoNotification("playing title " + title)
-    xbmcplugin.setResolvedUrl(__handle__, True, listitem=play_item)
+    # Just a video, pass the item to the Kodi player.
+    showInfoNotification("playing title " + result['title'])
+    xbmcplugin.setResolvedUrl(__handle__, True, listitem=getPlayItemFromVideo(result))

--- a/service.py
+++ b/service.py
@@ -52,11 +52,14 @@ def getParams():
 def getPlayItemFromVideo(video):
     debug(video)
     url = video['url']
-    thumbnail = video['thumbnail']
+    thumbnail = video.get('thumbnail')
     title = video['title']
     play_item = xbmcgui.ListItem(title, path=url)
     play_item.setInfo(type='Video', infoLabels={'Title': title})
-    play_item.setArt({'thumb': thumbnail})
+
+    if thumbnail is not None:
+        play_item.setArt({'thumb': thumbnail})
+
     return play_item
 
 


### PR DESCRIPTION
This PR checks for a thumbnail to exist before setting art on the ListItem. In the case where a thumbnail didn't exist, the plugin would fail to play the video because of the KeyError exception being thrown.

I also added a commit putting some repetitive code into a function before introducing my fix.

Thanks for the plugin, it works really well!