### PR TITLE
pass credentials to youtube-dl. provide json string as additional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ TypeError: attribute of type 'NoneType' is not callable
 	"id": 1
 }
 ```
+#### Example JSON Request with youtube-dl authentication
+```
+{
+	"jsonrpc": "2.0",
+	"method": "Player.Open",
+	"params": {
+		"item": {
+			"file": "plugin://plugin.video.sendtokodi/?https://vk.com/video-124136901_456239025 {\"ydlOpts\":{\"username\":\"user@email.com\",\"password\":\"password with spaces\"}}"
+		}
+	},
+	"id": 1
+}
+```
+Note: ydlOpts object will be passed directly to youtube-dl, so you can pass any [options](https://github.com/rg3/youtube-dl#options) that youtube-dl provides.
 #### Test with [Postman](https://www.getpostman.com/)
 
 - create new HTTP Request (POST)

--- a/service.py
+++ b/service.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
+import json
 import os
-import shlex
 import sys
 import xbmc
 import xbmcaddon
@@ -47,34 +47,17 @@ __handle__ = int(sys.argv[1])
 
 
 def getParams():
-    allowedArgs = {
-        '--password': 'password',
-        '-p': 'password',
-        '--username': 'username',
-        '-u': 'username',
-    }
+    result = {}
     paramstring = sys.argv[2]
-    additionalArgsIndex = paramstring.find(' ')
-    if additionalArgsIndex == -1:
-        cleanUrl = paramstring[1:]
-        additionalArgsString = ''
+    additionalParamsIndex = paramstring.find(' ')
+    if additionalParamsIndex == -1:
+        result['url'] = paramstring[1:]
+        result['ydlOpts'] = {}
     else:
-        cleanUrl = paramstring[1:additionalArgsIndex]
-        additionalArgsString = paramstring[additionalArgsIndex:]
-    additionalArgs = shlex.split(additionalArgsString) # shlex will get --username USERNAME --password "PASS WORD" and return ["--username", "USERNAME", "--password", "PASS WORD"]. if you provide shlex "   "(empty string), shlex will return empty array
-    result = {
-        'url': cleanUrl
-    }
-    argName = None
-    for arg in additionalArgs:
-        if argName is None:
-            if arg in allowedArgs:
-                argName = allowedArgs[arg]
-            else:
-                raise ValueError(arg + ' arg is not a valid argument. allowed arguments: [' + ', '.join(allowedArgs.keys()) + ']')
-        else:
-            result[argName] = arg
-            argName = None
+        result['url'] = paramstring[1:additionalParamsIndex]
+        additionalParamsString = paramstring[additionalParamsIndex:]
+        additionalParams = json.loads(additionalParamsString)
+        result['ydlOpts'] = additionalParams['ydlOpts']
     return result
 
 
@@ -98,10 +81,7 @@ ydl_opts = {
 
 params = getParams()
 url = str(params['url'])
-if 'username' in params:
-    ydl_opts['username'] = params['username']
-if 'password' in params:
-    ydl_opts['password'] = params['password']
+ydl_opts.update(params['ydlOpts'])
 ydl = YoutubeDL(ydl_opts)
 ydl.add_default_info_extractors()
 


### PR DESCRIPTION
Hey!

Thanks for your work, it's awesome! 
So, I've been using your plugin recently through curl and was really missing youtube-dl credentials part because every other video on vk.com requires you to authenticate.

So, basically what I do is snatch url then build dict with additional params, which further is pushed in ydl_opts if anything was provided.

Hope to hear from you soon, thanks!