### PR TITLE
Fix youtube-dl NoneType bug

### DIFF
--- a/service.py
+++ b/service.py
@@ -6,16 +6,11 @@ import xbmc
 import xbmcaddon
 import xbmcgui
 import xbmcplugin
-from youtube_dl import YoutubeDL
-
 
 class replacement_stderr(sys.stderr.__class__):
     def isatty(self): return False
 
-
 sys.stderr.__class__ = replacement_stderr
-
-
 
 def debug(content):
     log(content, xbmc.LOGDEBUG)
@@ -29,6 +24,48 @@ def log(msg, level=xbmc.LOGNOTICE):
     addon = xbmcaddon.Addon()
     addonID = addon.getAddonInfo('id')
     xbmc.log('%s: %s' % (addonID, msg), level)
+
+
+
+
+from contextlib import closing
+from xbmcvfs import File
+
+# fixes python caching bug in youtube-dl
+def patchYoutubeDL():
+    
+    toBePatched = """for expression in date_formats(day_first):
+        try:
+            upload_date = datetime.datetime.strptime(date_str, expression).strftime('%Y%m%d')
+        except ValueError:
+            pass
+    if upload_date is None:""" # last line ensures we won't patch it repeatedly
+
+    patch = """for expression in date_formats(day_first):
+        try:
+            upload_date = datetime.datetime.strptime(date_str, expression).strftime('%Y%m%d')
+        except ValueError:
+            pass
+        except:
+            pass
+    if upload_date is None:""" # last line ensures we won't patch it repeatedly
+
+    addonPath = xbmcaddon.Addon().getAddonInfo('path') 
+    youtubeDlPath = addonPath + "/youtube_dl"
+    utilsPyPath = youtubeDlPath + '/utils.py'
+
+    # Borrowed from https://forum.kodi.tv/showthread.php?tid=315590
+    with closing(File(utilsPyPath, 'r')) as fo:
+	    fileData = fo.read()
+
+    dataToWrite = fileData.replace(toBePatched, patch)
+
+    with closing(File(utilsPyPath, 'w')) as fo:
+	    fo.write(dataToWrite)
+
+patchYoutubeDL()
+
+from youtube_dl import YoutubeDL
 
 
 def showInfoNotification(message):
@@ -73,7 +110,8 @@ def createListItemFromVideo(video):
         list_item.setArt({'thumb': thumbnail})
 
     return list_item
-   
+
+
 
 ydl_opts = {
     'format': 'best'


### PR DESCRIPTION
Patch utils.py at runtime in order to avoid having to rebase youtube-dl every time it's updated

I've tested it twice to make sure it actually can play two videos consecutively, but I made some edits while creating the PR, so please test it by inspecting `utils.py` after it's been run and make sure the patched code at line 1263 looks correct.