### PR TITLE
Ci extensions

### DIFF
--- a/.github/scripts/build-script.sh
+++ b/.github/scripts/build-script.sh
@@ -1,8 +1,10 @@
 REPO_NAME=$1
 REPO_URL=$2
 
-cd ..
+set -e # if one command fails, abort the whole build and release process
+
 # clone repo
+cd ..
 git clone https://$REPO_URL
 
 # package addon
@@ -11,10 +13,14 @@ cp $REPO_NAME/$ADDON_NAME/addon.xml $ADDON_NAME # copy addon.xml to addon folder
 zip -r $ADDON_NAME-$VERSION.zip $ADDON_NAME  -x "*.git*" # create zip
 cp $ADDON_NAME-$VERSION.zip $REPO_NAME/$ADDON_NAME/ # copy source code to repo
 
-# commit & push
-cd $REPO_NAME/
-envsubst < "addon.template.xml" > "addon.xml"
-md5sum addon.xml > addon.xml.md5
-git add .
-git commit -m "CI Update"
-git push --force --quiet "https://firsttris:$TOKEN@$REPO_URL" master
+# commit & push if the ci was triggered by the main repo (diables trying to release for forks)
+if [[ $GITHUB_REPOSITORY == "firsttris/plugin.video.sendtokodi" ]]; then
+    cd $REPO_NAME/
+    envsubst < "addon.template.xml" > "addon.xml"
+    md5sum addon.xml > addon.xml.md5
+    git add .
+    git commit -m "CI Update"
+    git push --force --quiet "https://firsttris:$TOKEN@$REPO_URL" master
+else 
+    echo "Not in the main repo, build will not be released."
+fi

--- a/.github/scripts/build-script.sh
+++ b/.github/scripts/build-script.sh
@@ -8,7 +8,7 @@ git clone https://$REPO_URL
 # package addon
 envsubst < "$REPO_NAME/$ADDON_NAME/addon.template.xml" > "$REPO_NAME/$ADDON_NAME/addon.xml" # addon.xml
 cp $REPO_NAME/$ADDON_NAME/addon.xml $ADDON_NAME # copy addon.xml to addon folder
-zip -r $ADDON_NAME-$VERSION.zip $ADDON_NAME # create zip
+zip -r $ADDON_NAME-$VERSION.zip $ADDON_NAME  -x "*.git*" # create zip
 cp $ADDON_NAME-$VERSION.zip $REPO_NAME/$ADDON_NAME/ # copy source code to repo
 
 # commit & push

--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -23,3 +23,11 @@ jobs:
       - run: git config --global user.name "firsttris"    
       - run: $GITHUB_WORKSPACE/.github/scripts/build-script.sh $REPO_NAME_PYTHON2 $REPO_URL_PYTHON2
       - run: $GITHUB_WORKSPACE/.github/scripts/build-script.sh $REPO_NAME_PYTHON3 $REPO_URL_PYTHON3
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Addon-artifacts-python2
+          path: "/home/runner/work/${{ github.event.repository.name }}/${{ env.REPO_NAME_PYTHON2 }}/${{ env.ADDON_NAME }}/*${{ env.VERSION }}.zip"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Addon-artifacts-python3
+          path: "/home/runner/work/${{ github.event.repository.name }}/${{ env.REPO_NAME_PYTHON3 }}/${{ env.ADDON_NAME }}/*${{ env.VERSION }}.zip"

--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/checkout@v2
         with: 
           submodules: recursive 
-      - run: rm -rf .git/
       - run: git config --global user.email "tristanteufel@googlemail.com"
       - run: git config --global user.name "firsttris"    
       - run: chmod +x $GITHUB_WORKSPACE/.github/scripts/build-script.sh

--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -21,6 +21,5 @@ jobs:
           submodules: recursive 
       - run: git config --global user.email "tristanteufel@googlemail.com"
       - run: git config --global user.name "firsttris"    
-      - run: chmod +x $GITHUB_WORKSPACE/.github/scripts/build-script.sh
       - run: $GITHUB_WORKSPACE/.github/scripts/build-script.sh $REPO_NAME_PYTHON2 $REPO_URL_PYTHON2
       - run: $GITHUB_WORKSPACE/.github/scripts/build-script.sh $REPO_NAME_PYTHON3 $REPO_URL_PYTHON3


### PR DESCRIPTION
This keeps your automatic release while enabling building for forks as well. I hope you like the changes but if not, simply do not merge (or just cherry pick) this request. I was just setting up the ci in my fork a bit to work on the `yt-dlp` more efficiently without breaking the release files (again). 

In detail:

- Store created addon zip files as github artifacts (default 90 days retention). This does not hurt the main repo and is useful to test forks.
- The build script can be run by forks and locally (so one could test changes before pushing) to create addon zip files as well. The script will now not try to push to your release repos.
- The build script is executable by default (no need to `chmod` in the workflow yaml) 
- All `.git*` files and directories are ignored in the zip file creation (instead of `rm .git`). This avoids the action, the submodules .git files etc.
