### PR TITLE
Use patchted version of youtube-dl

### DIFF
--- a/.github/scripts/update-lib.sh
+++ b/.github/scripts/update-lib.sh
@@ -4,11 +4,11 @@ set -e
 # In case the remote commit is different, this script clones the remote repo and adds just the desired folder to our repo. 
 LIB_NAME=$1    
 LIB_GIT_URL=$2
-LIB_UPSTREAM_FOLDER=$3
+LIB_BRANCH=$3
 LIB_VERSION_FILE=${GITHUB_WORKSPACE}/lib/${LIB_NAME}_version
 
 
-commit_upstream=$(git ls-remote $LIB_GIT_URL HEAD | awk '{ print $1 }')
+commit_upstream=$(git ls-remote $LIB_GIT_URL $LIB_BRANCH | awk '{ print $1 }')
 commit_local=$(<${LIB_VERSION_FILE})
 
 
@@ -23,9 +23,10 @@ else
     mv /tmp/${LIB_NAME}/${LIB_NAME} ${GITHUB_WORKSPACE}/lib/${LIB_NAME}
     echo -n $commit_upstream > $LIB_VERSION_FILE
 
-    # commit here and push outside (one push for all changes, so the following build workflow will only be triggered once)
+    # commit changes to libs here but push outside of this script
+    # (one push for all libs thus the build workflow will only be triggered once)
     git add lib/${LIB_NAME} $LIB_VERSION_FILE
-    git commit -m "[CI] auto updated lib/${LIB_NAME} to upstream commit $commit_upstream"
+    git commit -m "[CI] auto update ${LIB_NAME} to upstream commit $commit_upstream"
 
     echo "$LIB_NAME succesfully upgraded to upstream commit $commit_upstream and staged for push"
 fi

--- a/.github/workflows/update-libs.yml
+++ b/.github/workflows/update-libs.yml
@@ -12,6 +12,6 @@ jobs:
           token: ${{ secrets.PAT }}
       - run: git config --global user.name "github-actions[bot]"
       - run: git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - run: $GITHUB_WORKSPACE/.github/scripts/update-lib.sh yt_dlp https://github.com/yt-dlp/yt-dlp.git yt_dlp
-      - run: $GITHUB_WORKSPACE/.github/scripts/update-lib.sh youtube_dl https://github.com/ytdl-org/youtube-dl.git youtube_dl
+      - run: $GITHUB_WORKSPACE/.github/scripts/update-lib.sh yt_dlp https://github.com/yt-dlp/yt-dlp.git HEAD
+      - run: $GITHUB_WORKSPACE/.github/scripts/update-lib.sh youtube_dl https://github.com/nullket/youtube-dl youtube-dl-patched-repo
       - run: git push


### PR DESCRIPTION
This "fixes" the youtube throttling for python2 user.

I have forked [dirkf's youtube-dl version](https://github.com/dirkf/youtube-dl/tree/df-youtube-unthrottle-patch) in which he has patched youtube. The fork is under my namespace, thus the repo does not automatically update and is therefore less error prone in terms of unintended changes (take down of the repo, malicious code pushes etc.) The repo can be found [here](https://github.com/nullket/youtube-dl/tree/df-youtube-unthrottle-patch).

I made some smaller adjustments to the update script/workflow in order to allow the specification of a desired branch (in case of youtube-dlp it is still HEAD to follow master/main/development or whatever the "main" branch is called). 

I would see this temporary:

- If youtube-dl comes back we should switch back
- If temporary as in terms of nobody uses kodi leia anymore.


@firsttris ready to be merged but I would not be to sad if you would disagree with the workaround. 