### PR TITLE
Revert to original youtube-dl repo

### DIFF
--- a/.github/workflows/update-libs.yml
+++ b/.github/workflows/update-libs.yml
@@ -13,5 +13,5 @@ jobs:
       - run: git config --global user.name "github-actions[bot]"
       - run: git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - run: $GITHUB_WORKSPACE/.github/scripts/update-lib.sh yt_dlp https://github.com/yt-dlp/yt-dlp.git master
-      - run: $GITHUB_WORKSPACE/.github/scripts/update-lib.sh youtube_dl https://github.com/nullket/youtube-dl df-youtube-unthrottle-patch
+      - run: $GITHUB_WORKSPACE/.github/scripts/update-lib.sh youtube_dl https://github.com/ytdl-org/youtube-dl master
       - run: git push


### PR DESCRIPTION
The original youtube-dl repo is maintained again. So let's not use our patched fork (which broke recently due to changes on youtube.com). yt-dlp still remains the default for sendtokodi. youtube-dl does not have a new stable release yet.

Users can still choose between the revolvers. 