### PR TITLE
Downgrade xbmc.python version for kodi 17/18

### DIFF
--- a/.github/scripts/build-addon.sh
+++ b/.github/scripts/build-addon.sh
@@ -15,7 +15,7 @@ fi
 case $KODI_TARGET in
   "Leia")
     echo -n "TODO"
-    $GITHUB_WORKSPACE/.github/scripts/addon_xml_adjuster.py --plugin-version $VERSION --xbmc-python "2.26.0"
+    $GITHUB_WORKSPACE/.github/scripts/addon_xml_adjuster.py --plugin-version $VERSION --xbmc-python "2.25.0"
     build_folder=Leia
     ;;
 


### PR DESCRIPTION
- Kodi 17 supports 2.25.0 
- Kodi 18 ships with 2.26.0
- There was no particular known reason for the version upgrade
- Roll back and hope that it wont break the plugin for Kodi 18 users
- Kodi 19/20 users stay unaffected 


closes #57 