### PR TITLE
Create issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps and/or URL of you media to reproduce the problem
+
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+
+**Kodi and sendtokodi version (please complete the following information):**
+ - Kodi: [e.g. Matrix]
+ - Addon: [e.g. 0.9.1]
+
+
+**Provide a Kodi log**
+- If you do not know how the get the log check the official [Kodi wiki](https://kodi.wiki/view/Log_file) 
+```log
+
+replace this line with your log
+
+```
+
+
+**In case a certain website does not work for you**
+- sendtokodi uses a third-party resolver to extract playable media URLs from your input
+- You can choose between [youtube-dl](https://github.com/ytdl-org/youtube-dl) and [yt-dlp](https://github.com/yt-dlp/yt-dlp)
+  - If you have not changed anything in the setting the default is yt-dlp for kodi 19 and above and youtube-dl fro earlier versions 
+- Please search their issue trackers and make sure that the issue is not already known there but an actual problem with sendtokodi
+- In case they have an issue there is nothing we can do but wait. sendtokodi will automatically be updated as soon as they release a fix.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,9 +35,10 @@ replace this line with your log
 **In case a certain website does not work for you**
 - sendtokodi uses a third-party resolver to extract playable media URLs from your input
 - You can choose between [youtube-dl](https://github.com/ytdl-org/youtube-dl) and [yt-dlp](https://github.com/yt-dlp/yt-dlp)
-  - If you have not changed anything in the setting the default is yt-dlp for kodi 19 and above and youtube-dl fro earlier versions 
-- Please search their issue trackers and make sure that the issue is not already known there but an actual problem with sendtokodi
-- In case they have an issue there is nothing we can do but wait. sendtokodi will automatically be updated as soon as they release a fix.
+  - If you have not changed anything in the addon settings the default is yt-dlp for kodi 19 and above while it is youtube-dl for earlier versions 
+- Please search their corresponding issue tracker and make sure that the issue is not already known there but an actual problem with sendtokodi
+- In case they have an issue on the topic already, there is nothing we can do but wait. 
+  - sendtokodi will automatically be updated as soon as they release a fix.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.


### PR DESCRIPTION
Hey @firsttris,

to help users and us with resolver issues (e.g.g https://github.com/firsttris/plugin.video.sendtokodi/issues/64 ) I thought about adding an issue template. What do you think? The wording can be adjusted of course.

If you do not like the idea, I have no problem with getting this PR declined.  

![grafik](https://user-images.githubusercontent.com/25816243/171903636-ef8f690a-2ea1-4197-a00d-ef091401dd5b.png)
