### PR TITLE
fix crash with multiple entries

### DIFF
--- a/service.py
+++ b/service.py
@@ -182,7 +182,7 @@ if 'entries' in result:
     if indexToStartAt == None:
         indexToStartAt = 0
 
-    unresolvedEntries = result['entries']
+    unresolvedEntries = list(result['entries'])
     startingEntry = unresolvedEntries.pop(indexToStartAt)
 
     # populate the queue with unresolved entries so that the starting entry can be inserted


### PR DESCRIPTION
After updating to LibreELEC 10 (using Kodi 19 and python3) sendtokodi seems to be crashing on URLs that generate multiple streams.

This commit fixes the issue for me. I have no idea if the fix is correct or complete.