### PR TITLE
Support video descriptions for resolved items

### DIFF
--- a/service.py
+++ b/service.py
@@ -77,8 +77,9 @@ def createListItemFromVideo(video):
     url = video['url']
     thumbnail = video.get('thumbnail')
     title = video['title']
+    description = video['description'] if 'description' in video else None
     list_item = xbmcgui.ListItem(title, path=url)
-    list_item.setInfo(type='Video', infoLabels={'Title': title})
+    list_item.setInfo(type='Video', infoLabels={'Title': title, 'plot': description})
 
     if thumbnail is not None:
         list_item.setArt({'thumb': thumbnail})


### PR DESCRIPTION
Video descriptions can be viewed in the Kodi player view. 

This doesn't add descriptions to the list view since the youtube extractor doesn't seem to provide descriptions when extracting flat playlists, but at least you should be able to view it after you start watching (default hotkey `I`).

Video dates should be interesting too.