### PR TITLE
switch to (not updated) progress bar instead of notification

### DIFF
--- a/service.py
+++ b/service.py
@@ -258,8 +258,10 @@ ydl = YoutubeDL(ydl_opts)
 ydl.add_default_info_extractors()
 
 with ydl:
-    showInfoNotification("Resolving stream(s) for " + url)
+    progress = xbmcgui.DialogProgressBG()
+    progress.create("Resolving " + url)
     result = ydl.extract_info(url, download=False)
+    progress.close()
 
 if 'entries' in result:
     # more than one video

--- a/service.py
+++ b/service.py
@@ -260,7 +260,14 @@ ydl.add_default_info_extractors()
 with ydl:
     progress = xbmcgui.DialogProgressBG()
     progress.create("Resolving " + url)
-    result = ydl.extract_info(url, download=False)
+    try:
+        result = ydl.extract_info(url, download=False)
+    except:
+        progress.close()
+        showErrorNotification("Could not resolve the url, check the log for more info")
+        import traceback
+        log(msg=traceback.format_exc(), level=xbmc.LOGERROR)
+        exit()
     progress.close()
 
 if 'entries' in result:


### PR DESCRIPTION
This should close https://github.com/firsttris/plugin.video.sendtokodi/issues/73. 

Instead of a notification ("Resolving..") with a fixed 5 s length, the plugin now shows the kodi background progress element. This background progress bar is similar to a notification (not a full screen, non blocking). As we have no progress update from yt-dlp we can not update this gui element with a real progress. On my tested skins this would not matter as a progress bar with 0 % still looks much better than a notification with 5 s which is still visible after the video has started. 

But before we merge I would like to have somebody (e.g. [GautamMKGarg](https://github.com/GautamMKGarg)) to test it. 