### PR TITLE
Fix manifest bool setting parsing

### DIFF
--- a/service.py
+++ b/service.py
@@ -144,7 +144,7 @@ def check_if_kodi_supports_manifest(url):
 def createListItemFromVideo(result):
     debug(result)
     adaptive_type = False
-    if xbmcplugin.getSetting(int(sys.argv[1]),"usemanifest"):
+    if xbmcplugin.getSetting(int(sys.argv[1]),"usemanifest") == 'true':
         url = extract_manifest_url(result)
         if url is not None:
             log("found original manifest: " + url)
@@ -252,7 +252,7 @@ ydl_opts = {
 params = getParams()
 url = str(params['url'])
 ydl_opts.update(params['ydlOpts'])
-if xbmcplugin.getSetting(int(sys.argv[1]),"usemanifest"):
+if xbmcplugin.getSetting(int(sys.argv[1]),"usemanifest") == 'true':
     ydl_opts['format'] = 'bestvideo*+bestaudio/best'
 ydl = YoutubeDL(ydl_opts)
 ydl.add_default_info_extractors()


### PR DESCRIPTION
- kodi boolean settings will be given as strings with `'true'` or `'false'`  
- I assumed them to be of type bool instead. The manifest settings is therefore always true
- Once we add more boolean settings (or do refactoring) we should think about a functional wrapper e.g. other plugins have something like [this](https://github.com/anxdpanic/plugin.video.youtube/blob/36e037518bbb14a06a4928c9dd5b77baaa70c3d3/resources/lib/youtube_plugin/kodion/impl/abstract_settings.py#L55)

Solves the first half of https://github.com/firsttris/plugin.video.sendtokodi/issues/77

I am merging it directly into master because the current state is broken and this fix is small.