### PR TITLE
Use existing manifest as default setting

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -21,7 +21,7 @@
 				<setting label="33010" type="action" action="RunScript(script.module.inputstreamhelper,info)"/>
 				<setting type="boolean" id="usemanifest" label="33011">
 					<level>0</level>
-					<default>false</default>
+					<default>true</default>
 					<control type="toggle" />
 				</setting>
 			</group>


### PR DESCRIPTION
@firsttris The usage of available manifests is possible since https://github.com/firsttris/plugin.video.sendtokodi/pull/74. As part of this initial support the default setting was false to gain some experience before enabling it for everyone. In order to proceed with [the ](https://github.com/firsttris/plugin.video.sendtokodi/issues/34) I would like to switch this now to on per default. Might break a page or two in case of unknown bugs (while still repairing a lot of them per default).