### PR TITLE
Introduces DASH manifest builder for YouTube

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -3,6 +3,7 @@
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
     <import addon="script.module.inputstreamhelper" version="0.4.2"/>
+    <import addon="script.module.requests" version="2.31.0" />
   </requires>
   <extension point="xbmc.python.pluginsource" library="service.py">
       <provides>video</provides>

--- a/dash_builder.py
+++ b/dash_builder.py
@@ -1,0 +1,216 @@
+import requests
+import struct
+from io import BytesIO
+from xml.etree.ElementTree import ElementTree, Element, SubElement, Comment, indent
+import http.server
+from threading import Thread
+
+def _webm_decode_int(byte):
+    # Returns size and value
+    if byte >= 128:
+        return 1, byte & 0b1111111
+    elif byte >= 64:
+        return 2, byte & 0b111111
+    elif byte >= 32:
+        return 3, byte & 0b11111
+    elif byte >= 16:
+        return 4, byte & 0b1111
+    elif byte >= 8:
+        return 5, byte & 0b111
+    elif byte >= 4:
+        return 6, byte & 0b11
+    elif byte >= 2:
+        return 7, byte & 0b1
+    return 8, 0
+
+def _webm_find_init_and_index_ranges(r):
+    # Walk over the stream and find the offset of the 'Cues' element
+    # This isn't so easy due to the EBML encoding
+    init_range = (0,0)
+    index_range = (0,0)
+
+    # Verify the EMBL signature / root element
+    signature = struct.unpack('>I', r.content[0:4])[0]
+    if signature != 0x1A45DFA3:
+        return init_range, index_range
+
+    offset = 5
+    while offset < len(r.content) - 16:
+        # Get the element ID
+        id_len, _ = _webm_decode_int(r.content[offset])
+        id = int.from_bytes(r.content[offset:offset+id_len], byteorder='big', signed=False)
+
+        # Get the size of the element
+        size_len, sz = _webm_decode_int(r.content[offset+id_len])
+        size_bytes = bytearray() + sz.to_bytes()
+        begin = offset + id_len + 1
+        end = offset + id_len + size_len
+        size_bytes += r.content[begin:end]
+        size = int.from_bytes(size_bytes, byteorder='big', signed=False)
+
+        # Check if we have found the 'Cues' element we are looking for
+        if id == 0x1C53BB6B:
+            init_range = (0, offset - 1)
+            index_range = (offset, offset + id_len + size_len + size - 1)
+            break
+
+        # Check if we have found the Matroska Segment, which is of unknown size,
+        # and advance through the stream to the next element
+        if id == 0x18538067:
+            offset += id_len + size_len
+        else:
+            offset += id_len + size_len + size
+
+    return init_range, index_range
+
+def _mp4_find_init_and_index_ranges(r):
+    # Walk over the stream and find the offset of the sidx box
+    # Fortunately this is much easier than webm
+    init_range = None
+    index_range = None
+    offset = 0
+    while offset < len(r.content) - 8:
+        box_size = struct.unpack('>I', r.content[offset:offset + 4])[0]
+        box_type = struct.unpack('4s', r.content[offset + 4:offset + 8])[0]
+        if box_type == b"sidx":
+            init_range = (0, offset - 1)
+            index_range = (offset, offset + box_size - 1)
+            break
+        offset = offset + box_size
+    return init_range, index_range
+
+def find_init_and_index_ranges(url, container):
+    # Download the first 1KiB of the stream
+    init_range = None
+    index_range = None
+    size = 1024
+    r = requests.get(url, headers={'Range':'bytes=0-' + str(size - 1)})
+    if container == 'webm_dash':
+        return _webm_find_init_and_index_ranges(r)
+    return _mp4_find_init_and_index_ranges(r)
+
+def _iso8601_duration(secs):
+    m, s = divmod(secs, 60)
+    h, m = divmod(m, 60)
+    d, h = divmod(h, 24)
+    return f"P{int(d)}DT{int(h)}H{int(m)}M{s}S"
+
+def transform_url(url):
+    return url.replace('&', '/').replace('?', '/').replace('=', '/')
+
+
+class Manifest():
+    def __init__(self, duration):
+        self.mpd = Element('MPD')
+        self.mpd.set('xmlns', 'urn:mpeg:DASH:schema:MPD:2011')
+        self.mpd.set('profiles', 'urn:mpeg:dash:profile:isoff-main:2011')
+        self.mpd.set('type', 'static')
+        self.mpd.set('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance')
+        self.mpd.set('xsi:schemaLocation', 'urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd')
+        self.mpd.set('minBufferTime', _iso8601_duration(1.5))
+        self.mpd.set('mediaPresentationDuration', _iso8601_duration(duration))
+
+        self.period = SubElement(self.mpd, 'Period')
+
+        self.audio_set = SubElement(self.period, 'AdaptationSet')
+        self.audio_set.set('id', '0')
+        self.audio_set.set('subsegmentAlignment', 'true')
+        self.audio_set.set('contentType', 'audio')
+
+        self.audio_set_role = SubElement(self.audio_set, 'Role')
+        self.audio_set_role.set('schemeIdUri', 'urn:mpeg:DASH:role:2011')
+        self.audio_set_role.set('value', 'main')
+
+        self.video_set = SubElement(self.period, 'AdaptationSet')
+        self.video_set.set('id', '1')
+        self.video_set.set('subsegmentAlignment', 'true')
+        self.video_set.set('contentType', 'video')
+
+        self.video_set_role = SubElement(self.video_set, 'Role')
+        self.video_set_role.set('schemeIdUri', 'urn:mpeg:DASH:role:2011')
+        self.video_set_role.set('value', 'main')
+
+        self.tree = ElementTree(self.mpd)
+
+    def add_audio_format(self, format):
+        rep = SubElement(self.audio_set, 'Representation')
+        rep.set('id', format['format_id'].split('-',1)[0])
+        rep.set('codecs', format['acodec'])
+        rep.set('audioSamplingRate', str(format['asr']))
+        rep.set('startWithSAP', '1')
+        rep.set('mimeType', f"audio/{format['ext']}")
+
+        channels = SubElement(rep, 'AudioChannelConfiguration')
+        channels.set('schemeIdUri', 'urn:mpeg:dash:23003:3:audio_channel_configuration:2011')
+        channels.set('value', str(format['audio_channels']))
+
+        url = transform_url(format['url'])
+        base_url = SubElement(rep, 'BaseURL')
+        base_url.text = url
+
+        init_range, idx_range = find_init_and_index_ranges(url, format['container'])
+        segment_base = SubElement(rep, 'SegmentBase')
+        segment_base.set('indexRange', f'{idx_range[0]}-{idx_range[1]}')
+
+        init = SubElement(segment_base, 'Initialization')
+        init.set('range', f'{init_range[0]}-{init_range[1]}')
+
+    def add_video_format(self, format):
+        rep = SubElement(self.video_set, 'Representation')
+        rep.set('id', format['format_id'].split('-',1)[0])
+        rep.set('codecs', format['vcodec'])
+        rep.set('startWithSAP', '1')
+        rep.set('maxPlayoutRate', '1')
+        rep.set('frameRate', str(format['fps']))
+        rep.set('width', str(format['resolution']).split('x',1)[0])
+        rep.set('height', str(format['resolution']).split('x',1)[1])
+        rep.set('mimeType', f"video/{format['ext']}")
+
+        url = transform_url(format['url'])
+        base_url = SubElement(rep, 'BaseURL')
+        base_url.text = url
+
+        init_range, idx_range = find_init_and_index_ranges(url, format['container'])
+        segment_base = SubElement(rep, 'SegmentBase')
+        segment_base.set('indexRange', f'{idx_range[0]}-{idx_range[1]}')
+
+        init = SubElement(segment_base, 'Initialization')
+        init.set('range', f'{init_range[0]}-{init_range[1]}')
+
+    def emit(self):
+        indent(self.tree)
+        f = BytesIO()
+        self.tree.write(f, encoding='utf-8', xml_declaration=True)
+        #self.tree.write('manifest.mpd', encoding='utf-8', xml_declaration=True)
+        return f.getvalue()
+
+
+class HttpHandler(http.server.BaseHTTPRequestHandler):
+    def __init__(self, request, client_address, server):
+        super().__init__(request, client_address, server)
+        self.mpd = None
+
+    def do_HEAD(self):
+        self.send_response(200, 'OK')
+        self.send_header('Content-type', 'application/dash+xml')
+        self.send_header('Content-Length', str(len(bytes(self.mpd))))
+        self.end_headers()
+
+    def do_GET(self):
+        self.do_HEAD()
+        self.wfile.write(bytes(self.mpd))
+
+
+def _handle_request(httpd):
+    httpd.serve_forever()
+
+def start_httpd(manifest):
+    handler = HttpHandler
+    server_address = ('127.0.0.1', 0)
+    httpd = http.server.HTTPServer(server_address, handler)
+    httpd.timeout = 2
+    handler.mpd = manifest
+    thread = Thread(target=_handle_request, args=(httpd,))
+    thread.start()
+    return f"http://127.0.0.1:{httpd.server_port}/manifest.mpd"
+

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -48,3 +48,39 @@ msgctxt "#33011"
 msgid "Use original manifest (experimental)"
 msgstr ""
 
+msgctxt "#33020"
+msgid "Use DASH manifest builder (kodi 19+ only) (experimental)"
+msgstr ""
+
+msgctxt "#33030"
+msgid "Maximum resolution"
+msgstr ""
+
+msgctxt "#33031"
+msgid "7680x4320 (8k)"
+msgstr ""
+
+msgctxt "#33032"
+msgid "3840x2160 (4k)"
+msgstr ""
+
+msgctxt "#33033"
+msgid "2560x1440 (2k)"
+msgstr ""
+
+msgctxt "#33034"
+msgid "1920x1080 (FHD)"
+msgstr ""
+
+msgctxt "#33035"
+msgid "1280x720 (HD)"
+msgstr ""
+
+msgctxt "#33036"
+msgid "854x480 (SD)"
+msgstr ""
+
+msgctxt "#33040"
+msgid "Prefer AVC1/H.264/MP4"
+msgstr ""
+

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,30 +1,65 @@
 <?xml version="1.0" ?>
 <settings version="1">
-	<section id="plugin.video.sendtokodi">
-		<category id="general" label="32000">
-			<group id="1">
-				<setting id="resolver" type="integer" label="32020">
-					<level>0</level>
-					<default>1</default>
-					<constraints>
-						<options>
-							<option label="32021">0</option>
-							<option label="32022">1</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-			</group>
-		</category>
-		<category id="adaptive" label="33000">
-			<group id="2">
-				<setting label="33010" type="action" action="RunScript(script.module.inputstreamhelper,info)"/>
-				<setting type="boolean" id="usemanifest" label="33011">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle" />
-				</setting>
-			</group>
-		</category>
-	</section>
+    <section id="plugin.video.sendtokodi">
+        <category id="general" label="32000">
+            <group id="1">
+                <setting id="resolver" type="integer" label="32020">
+                    <level>0</level>
+                    <default>1</default>
+                    <constraints>
+                        <options>
+                            <option label="32021">0</option>
+                            <option label="32022">1</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+            </group>
+        </category>
+        <category id="adaptive" label="33000">
+            <group id="2">
+                <setting label="33010" type="action" action="RunScript(script.module.inputstreamhelper,info)"/>
+                <setting type="boolean" id="usemanifest" label="33011">
+                    <level>0</level>
+                    <default>true</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting type="boolean" id="usedashbuilder" label="33020">
+                    <level>0</level>
+                    <default>true</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting id="maxresolution" type="integer" label="33030">
+                    <level>0</level>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition setting="usedashbuilder" operator="is">true</condition>
+                        </dependency>
+                    </dependencies>
+                    <default>1920</default>
+                    <constraints>
+                        <options>
+                            <option label="33031">7680</option>
+                            <option label="33032">3840</option>
+                            <option label="33033">2560</option>
+                            <option label="33034">1920</option>
+                            <option label="33035">1280</option>
+                            <option label="33036">854</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+                <setting type="boolean" id="preferavc1" label="33040">
+                    <level>0</level>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition setting="usedashbuilder" operator="is">true</condition>
+                        </dependency>
+                    </dependencies>
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+        </category>
+    </section>
 </settings>


### PR DESCRIPTION
This introduces a DASH manifest builder that can generate a .mpd manifest from separate audio and video streams. 
It then spools up a web server and serves it to inputstream adaptive.

I have limited it to YouTube for now at least as I am not confident about other sites. YouTube videos are HD again, which was my main objective.

This should fully or partially resolve #110 and #34.  
Also resolves #118 albeit with a not-so-nice workaround. 

I have made a setting to enable/disable it and tried to leave the existing functionality untouched as much as possible.
Have also added a max resolution and a h264 preference option.

Many thanks to @nullket who's previous research on #34 set me on the right track.

Future enhancements:
 * Support other sites
 * Build a proper adaptive manifest with multiple formats