### PR TITLE
Ensure Python < 3.11 compatibility

### DIFF
--- a/dash_builder.py
+++ b/dash_builder.py
@@ -42,7 +42,7 @@ def _webm_find_init_and_index_ranges(r):
 
         # Get the size of the element
         size_len, sz = _webm_decode_int(r.content[offset+id_len])
-        size_bytes = bytearray() + sz.to_bytes()
+        size_bytes = bytearray() + sz.to_bytes(1, 'big')
         begin = offset + id_len + 1
         end = offset + id_len + size_len
         size_bytes += r.content[begin:end]


### PR DESCRIPTION
* Added "missing" default values for Python 3.2 to 3.10
* See: https://docs.python.org/3/library/stdtypes.html#int.to_bytes

Fixes a regression in #119