### PR TITLE
Deprecated: remove explicit setting of inputstream.adaptive.manifest_type

### DIFF
--- a/service.py
+++ b/service.py
@@ -221,7 +221,6 @@ def createListItemFromVideo(result):
         ])
     if adaptive_type:
         list_item.setProperty('inputstream', 'inputstream.adaptive')
-        list_item.setProperty('inputstream.adaptive.manifest_type', adaptive_type)
 
     return list_item
 


### PR DESCRIPTION
The `inputstream.adaptive.manifest_type` property is deprecated and will be removed next Kodi version, the manifest type is now automatically detected.