### PR TITLE
Ensure dash manifest http server is terminated after a timeout period

### DIFF
--- a/dash_builder.py
+++ b/dash_builder.py
@@ -70,7 +70,7 @@ def _mp4_find_init_and_index_ranges(r):
     index_range = None
     offset = 0
     while offset < len(r.content) - 8:
-        box_size = struct.unpack('>I', r.content[offset:offset + 4])[0]
+        box_size = max(struct.unpack('>I', r.content[offset:offset + 4])[0], 8)
         box_type = struct.unpack('4s', r.content[offset + 4:offset + 8])[0]
         if box_type == b"sidx":
             init_range = (0, offset - 1)
@@ -81,8 +81,6 @@ def _mp4_find_init_and_index_ranges(r):
 
 def find_init_and_index_ranges(url, container):
     # Download the first 1KiB of the stream
-    init_range = None
-    index_range = None
     size = 1024
     r = requests.get(url, headers={'Range':'bytes=0-' + str(size - 1)})
     if container == 'webm_dash':
@@ -214,10 +212,9 @@ def start_httpd(manifest):
 
     server_address = ('127.0.0.1', 0)
     httpd = http.server.HTTPServer(server_address, handler)
-    httpd.timeout = 2
+    httpd.timeout = 2  # Seconds
     httpd.handle_timeout = lambda: (_ for _ in ()).throw(TimeoutError())
 
     thread = Thread(target=_handle_request, args=(httpd,))
     thread.start()
     return f"http://127.0.0.1:{httpd.server_port}/manifest.mpd"
-

--- a/service.py
+++ b/service.py
@@ -322,7 +322,7 @@ if usedashbuilder:
     ydl_opts['format'] = f'bv{vcodec}[width<={maxresolution}]+ba/'
     ydl_opts['format'] += f'bv[width<={maxresolution}]+ba/'
     ydl_opts['format'] += f'b{vcodec}[width<={maxresolution}]/'
-    ydl_opts['format'] += f'b[width<={maxresolution}]'
+    ydl_opts['format'] += f'b[width<={maxresolution}]/'
     ydl_opts['format'] += f'b*'
 
 ydl = YoutubeDL(ydl_opts)


### PR DESCRIPTION
I noticed that the web server was not terminating itself after the timeout period (2 seconds). 

I had previously tested that it was working but then I moved to serve_forever() instead of handle_request(), which apparently ignores the configured timeout.

Also included a couple of other minor corrections.
