### PR TITLE
Overhaul stream selection

### DIFF
--- a/dash_builder.py
+++ b/dash_builder.py
@@ -137,6 +137,9 @@ class Manifest():
         rep.set('audioSamplingRate', str(format['asr']))
         rep.set('startWithSAP', '1')
         rep.set('mimeType', f"audio/{format['ext']}")
+        kbps = format.get('tbr', format.get('abr'))
+        if kbps is not None:
+            rep.set('bandwidth', str(int(kbps * 1000)))
 
         channels = SubElement(rep, 'AudioChannelConfiguration')
         channels.set('schemeIdUri', 'urn:mpeg:dash:23003:3:audio_channel_configuration:2011')
@@ -163,6 +166,9 @@ class Manifest():
         rep.set('width', str(format['resolution']).split('x',1)[0])
         rep.set('height', str(format['resolution']).split('x',1)[1])
         rep.set('mimeType', f"video/{format['ext']}")
+        kbps = format.get('tbr', format.get('vbr'))
+        if kbps is not None:
+            rep.set('bandwidth', str(int(kbps * 1000)))
 
         url = transform_url(format['url'])
         base_url = SubElement(rep, 'BaseURL')

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -80,7 +80,3 @@ msgctxt "#33036"
 msgid "854x480 (SD)"
 msgstr ""
 
-msgctxt "#33040"
-msgid "Prefer AVC1/H.264/MP4"
-msgstr ""
-

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -31,11 +31,6 @@
                 </setting>
                 <setting id="maxresolution" type="integer" label="33030">
                     <level>0</level>
-                    <dependencies>
-                        <dependency type="visible">
-                            <condition setting="usedashbuilder" operator="is">true</condition>
-                        </dependency>
-                    </dependencies>
                     <default>1920</default>
                     <constraints>
                         <options>
@@ -48,16 +43,6 @@
                         </options>
                     </constraints>
                     <control type="spinner" format="string"/>
-                </setting>
-                <setting type="boolean" id="preferavc1" label="33040">
-                    <level>0</level>
-                    <dependencies>
-                        <dependency type="visible">
-                            <condition setting="usedashbuilder" operator="is">true</condition>
-                        </dependency>
-                    </dependencies>
-                    <default>false</default>
-                    <control type="toggle"/>
                 </setting>
             </group>
         </category>

--- a/service.py
+++ b/service.py
@@ -377,12 +377,15 @@ if 'entries' in result:
 
     # populate the queue with unresolved entries so that the starting entry can be inserted
     for video in unresolvedEntries:
-        list_item = createListItemFromFlatPlaylistItem(video)
-        pl.add(list_item.getPath(), list_item)
+        if 'url' in video:
+            list_item = createListItemFromFlatPlaylistItem(video)
+            pl.add(list_item.getPath(), list_item)
 
     # make sure the starting ListItem has a resolved url, to avoid recursion and crashes
-    startingVideoUrl = startingEntry['url']
-    startingItem = createListItemFromVideo(ydl.extract_info(startingVideoUrl, download=False))
+    if 'url' in startingEntry:
+        startingItem = createListItemFromVideo(ydl.extract_info(startingEntry['url'], download=False))
+    else:
+        startingItem = createListItemFromVideo(startingEntry)
     pl.add(startingItem.getPath(), startingItem, indexToStartAt)
     
     #xbmc.Player().play(pl) # this probably works again

--- a/service.py
+++ b/service.py
@@ -172,7 +172,7 @@ def createListItemFromVideo(result):
                 break
 
             # MPEG-DASH streams without adaptive manifest:
-            if usedashbuilder and (not have_video or len(dash_video) > 0) and (not have_audio or len(dash_audio) > 0) and ((have_video and f == dash_video[-1]) or (not have_video and f == dash_audio[-1])) and isa_supports("mpd"):
+            if usedashbuilder and (not have_video or len(dash_video) > 0) and (not have_audio or len(dash_audio) > 0) and ((have_video and f == dash_video[-1]) or (not have_video and have_audio and f == dash_audio[-1])) and isa_supports("mpd"):
                 import dash_builder
                 builder = dash_builder.Manifest(result.get('duration', "0"))
                 video_success = not have_video

--- a/service.py
+++ b/service.py
@@ -209,7 +209,7 @@ def createListItemFromVideo(result):
             manifest_type = guess_manifest_type(f, f['url'])
             if manifest_type is not None and not isa_supports(manifest_type):
                 continue
-            if int(f.get('width', "0")) > maxwidth:
+            if f.get('width', 0) > maxwidth:
                 if filtered_format is None:
                     filtered_format = f
                 continue


### PR DESCRIPTION
The current stream selection mechanism operates in 2 modes:
"classic" mode where it unconditionally selects the top level `url` parameter
"manifest" mode where it tries
1. The top level `manifest_url` parameter.
2. Any `manifest_url` found in `requested_formats`.
3. To construct an DASH manifest from *_dash streams in `requested_formats` if `usedashbuilder` is turned on.
4. The `url` for the entry in `formats` where `vcodec` and `acodec` are set and not `"none"`, and if there's more than one, the one with the largest `width`.
5. If the top level `vcodec` isn't set or is `"none"`, the entry in `formats` that has the highest `abr`, or any entry that has `acodec` set to something other than `"none"`.

The way yt-dlp generally works today is by returning a ordered list of `formats`, sorted from lowest to highest quality, from which it can select relevant streams and put them in `requested_formats` based on the -f parameter.
- It may, on occasion, have no `formats` and instead just put simple results in a top level `url` parameter.
- If available, it will place a top level `manifest_url` parameter for what I'll refer to as an adaptive (in the sense that it contains multiple quality levels of both video and audio stream) manifest covering all `formats`.
- It may place a `manifest_url` in any entry in `formats` to indicate that this format and all of its siblings are covered by an adaptive manifest.
- The `acodec` may be set to `none` but the `manifest_url` covers audio anyway
- If it doesn't know whether a stream has video/audio it may omit `acodec` and `vcodec`

Based on @47Ohms comment in #127 that this plugin should ideally produce an adaptive manifest to InputStream.Adaptive and let Kodi sort out what to play, this patch changes the selection logic to a 3 step process:
1. The top level `manifest_url` parameter (the ideal situation).
2. Walk from highest to lowest quality and select the first format that is playable and contains all necessary streams, preferring the `manifest_url` and constructing a DASH manifest from all available DASH streams if necessary.
3. The top level `url`.

Because it never touches the `requested_formats`, the format parameter to ytdl is technically irrelevant. It's not that different from the current selection algorithm, just a tad more aggressive by excluding fewer formats. I find it difficult to get it to fail now.

This has, however, unmasked a few problems I was not aware of before. ISA seems to pick the stream with the highest acceptable resolution and then sorts all options by bitrate. As such, it will very consistently select VP9 over AV1 on YouTube. ISA has problems with ad breaks on Twitch.tv and will jump all over the place while logging AV sync errors but it does eventually return to the stream. ISA does not support [HLS streams with multiple audio streams](https://github.com/xbmc/inputstream.adaptive/wiki/Add%E2%80%90on-WIP-status) so on [YouTube videos that were uploaded at the right time to have HLS but not DASH streams](https://www.youtube.com/watch?v=ps_Ne2_pWUM), it will play without audio despite showing multiple audio streams. Switching audio stream in the OSD will make it play properly. ISA has a nebulous problem with multiple audio streams in DASH manifests where the audio will just disappear in the middle of a video and never come back. That last one I put in a temporary workaround for.

I have attempted to retain the existing options but folded them into the selection loop. As such, disabling `usemanifest` no longer precludes the use of ISA, just the use of adaptive manifests. `usedashbuilder` isn't dependent on `usemanifest` and doesn't cause selection to fail when enabled without `usemanifest` anymore. The `maxresolution` option is only used when the plugin is forced to select a specific quality level by itself. This happens very rarely from what I've found and there is one unimplemented case that can be added to make it effectively never but it requires building HLS manifests like it builds DASH manifests now. I have removed `preferavc1` because it's practically never honored. Finally, because `dash_builder` uses so many fields from the format unconditionally, I wrapped stream addition in try/catch blocks so that it can gracefully fall back. This doesn't quite render `usedashbuilder` pointless but if it were solely up to me I'd probably just remove it.

The result is that it will now play everything ytdl throws at it at the most appropriate quality level available.

Fixes #137 