### PR TITLE
dash_builder: set default range values for mp4_dash to 0

### DIFF
--- a/dash_builder.py
+++ b/dash_builder.py
@@ -66,8 +66,8 @@ def _webm_find_init_and_index_ranges(r):
 def _mp4_find_init_and_index_ranges(r):
     # Walk over the stream and find the offset of the sidx box
     # Fortunately this is much easier than webm
-    init_range = None
-    index_range = None
+    init_range = (0,0)
+    index_range = (0,0)
     offset = 0
     while offset < len(r.content) - 8:
         box_size = max(struct.unpack('>I', r.content[offset:offset + 4])[0], 8)


### PR DESCRIPTION
As I stated in #126, I'm not entirely certain this is correct. I managed to hit it in practice and it did make the video play properly but I can't reproduce the issue with the video anymore. At the very least I don't think it harms anything, and these values are used unconditionally in string formatting later, causing an exception if the sidx box isn't found.