### PR TITLE
Fix width == None

### DIFF
--- a/service.py
+++ b/service.py
@@ -209,7 +209,8 @@ def createListItemFromVideo(result):
             manifest_type = guess_manifest_type(f, f['url'])
             if manifest_type is not None and not isa_supports(manifest_type):
                 continue
-            if f.get('width', 0) > maxwidth:
+            width = f.get('width', 0)
+            if width is not None and width > maxwidth:
                 if filtered_format is None:
                     filtered_format = f
                 continue


### PR DESCRIPTION
Fixes regression noted on #133 where yt-dlp returns formats with width==None.