### PR TITLE
Fix crash and open settings when no parameters are passed

### DIFF
--- a/service.py
+++ b/service.py
@@ -320,7 +320,12 @@ def playlistIndex(url, playlist):
     
     return None
 
-
+# Open the settings if no parameters have been passed. Prevents crash.
+# This happens when the addon is launched from within the Kodi OSD.
+if not sys.argv[2]:
+    xbmcaddon.Addon().openSettings()
+    exit()
+    
 # Use the chosen resolver while forcing to use youtube_dl on legacy python 2 systems (dlp is python 3.6+)
 if xbmcplugin.getSetting(int(sys.argv[1]),"resolver") == "0" or sys.version_info[0] == 2:
     from youtube_dl import YoutubeDL


### PR DESCRIPTION
When you open the addon from within Kodi OSD, it crashes as no parameters are passed.
This change opens the settings menu instead.