### PR TITLE
Fix repository's addon.xml adjustment workflow

### DIFF
--- a/.github/scripts/publish-addon.sh
+++ b/.github/scripts/publish-addon.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
-# this script publishes the addon zip file to the unofficial python2/3 kodi repo 
+# this script publishes the addon zip file to the unofficial python2/3 kodi repo
 
-REPO_URL=$1
+VERSION=$1
+REPO_URL=$2
 REPO_FOLDER=release_repo
 
 # check if action was triggered in a fork and avoid trying to push. FOR TESTING DISABLED
@@ -17,13 +18,13 @@ if [[ $GITHUB_REPOSITORY == "firsttris/plugin.video.sendtokodi" ]]; then
     $GITHUB_WORKSPACE/.github/scripts/update-repo-xml.py --repo-root $REPO_FOLDER
     cd $REPO_FOLDER
     md5sum addon.xml > addon.xml.md5
-    
+
     # Add new addon zip file, the repo addon.xml, its md5 hash file and then commit and push
     git config --global user.name "github-actions[bot]"
     git config --global user.email "github-actions[bot]@users.noreply.github.com"
     git add .
     git commit -m "CI Update for $VERSION"
     git push --force --quiet "https://firsttris:$TOKEN@$REPO_URL" master
-else 
+else
     echo "Not in the main repo, build will not be published."
 fi

--- a/.github/scripts/publish-addon.sh
+++ b/.github/scripts/publish-addon.sh
@@ -2,8 +2,7 @@
 set -e
 # this script publishes the addon zip file to the unofficial python2/3 kodi repo 
 
-VERSION=$1
-REPO_URL=$2
+REPO_URL=$1
 REPO_FOLDER=release_repo
 
 # check if action was triggered in a fork and avoid trying to push. FOR TESTING DISABLED
@@ -14,10 +13,11 @@ if [[ $GITHUB_REPOSITORY == "firsttris/plugin.video.sendtokodi" ]]; then
     # add the plugin zip file
     mv plugin.video.sendtokodi-$VERSION.zip $REPO_FOLDER/plugin.video.sendtokodi/
 
-    # Update repository addon xml (not the plugin addon.xml) to include the latest version of sendtokodi
+    # Update repository's addon.xml with the addon's addon.xml
+    $GITHUB_WORKSPACE/.github/scripts/update-repo-xml.py --repo-root $REPO_FOLDER
     cd $REPO_FOLDER
-    envsubst < "addon.template.xml" > "addon.xml"  
     md5sum addon.xml > addon.xml.md5
+    
     # Add new addon zip file, the repo addon.xml, its md5 hash file and then commit and push
     git config --global user.name "github-actions[bot]"
     git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/scripts/update-repo-xml.py
+++ b/.github/scripts/update-repo-xml.py
@@ -1,0 +1,25 @@
+#!/bin/python3
+
+import os
+import argparse
+import xml.etree.ElementTree as ET
+
+# check and parse arguments
+parser = argparse.ArgumentParser()
+parser.add_argument("--repo-root", required=True)
+args = parser.parse_args()
+
+# get the addon's XML element
+src_filename = "addon.xml"
+src_tree = ET.parse(src_filename)
+src_element = src_tree.getroot()
+
+# instantiate the repo's XML template
+tpl_filename = os.path.join(args.repo_root, "addon.template.xml")
+tpl_tree = ET.parse(tpl_filename)
+tpl_element = tpl_tree.getroot()
+tpl_element.append(src_element)
+
+# write changes to the repo's addon.xml file
+dst_filename = os.path.join(args.repo_root, "addon.xml")
+tpl_tree.write(dst_filename, encoding='UTF-8', xml_declaration=True)  

--- a/.github/scripts/update-repo-xml.py
+++ b/.github/scripts/update-repo-xml.py
@@ -22,4 +22,4 @@ tpl_element.append(src_element)
 
 # write changes to the repo's addon.xml file
 dst_filename = os.path.join(args.repo_root, "addon.xml")
-tpl_tree.write(dst_filename, encoding='UTF-8', xml_declaration=True)  
+tpl_tree.write(dst_filename, encoding='UTF-8', xml_declaration=True)

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -40,4 +40,4 @@ jobs:
         with:
           name: Addon-artifacts
       - name: Publish addon
-        run: $GITHUB_WORKSPACE/.github/scripts/publish-addon.sh ${{ needs.versioning.outputs.VERSION }} "github.com/firsttris/repository.sendtokodi.git" 
+        run: $GITHUB_WORKSPACE/.github/scripts/publish-addon.sh "github.com/firsttris/repository.sendtokodi.git" 

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -40,4 +40,4 @@ jobs:
         with:
           name: Addon-artifacts
       - name: Publish addon
-        run: $GITHUB_WORKSPACE/.github/scripts/publish-addon.sh "github.com/firsttris/repository.sendtokodi.git" 
+        run: $GITHUB_WORKSPACE/.github/scripts/publish-addon.sh ${{ needs.versioning.outputs.VERSION }} "github.com/firsttris/repository.sendtokodi.git"


### PR DESCRIPTION
- Don't just update the version, update the entire addon element
- Avoids update anomalies because the template can't get outdated
- Depends on the template not containing a redundant addon element
- Fixed a few whitespace issues

Fixes #146 
Depends on https://github.com/firsttris/repository.sendtokodi/pull/6