### PR TITLE
Backport latest changes to Leia

### DIFF
--- a/dash_builder.py
+++ b/dash_builder.py
@@ -3,10 +3,7 @@ import struct
 from io import BytesIO
 from xml.etree.ElementTree import ElementTree, Element, SubElement, Comment
 from threading import Thread
-try:
-    from http.server import BaseHTTPRequestHandler, HTTPServer
-except ImportError:
-    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
 def _webm_decode_int(byte):
     # Returns size and value


### PR DESCRIPTION
This backport was meant to try https://python-future.org to keep the Python 3 and 2 codebases as much in sync as possible. However, it turned out that:
- the [Future](https://kodi.wiki/view/Add-on:Future) addon, while listed in the Leia addon repository's [wiki page](https://kodi.wiki/view/Category:Leia_add-on_repository), isn't actually available in the [repo](https://github.com/xbmc/repo-scripts/tree/leia) (while it is for [Matrix](https://github.com/xbmc/repo-scripts/tree/matrix)). That means we'd have to ship it manually.
- it *is* available on the Kodi [mirror](https://mirrors.kodi.tv/addons/leia/script.module.future/) for some reason, though
- the manually installed version (from the mirror) interfered with the Youtube-dl lib and broke it

So, for the time being I'm instead going to directly adapt the Python 2 codebase as needed. So far the differences are still just a few lines. I'll continue looking into possible improvements but with lower priority.