### PR TITLE
Fix regression in #147 (update version)

### DIFF
--- a/.github/scripts/publish-addon.sh
+++ b/.github/scripts/publish-addon.sh
@@ -15,7 +15,7 @@ if [[ $GITHUB_REPOSITORY == "firsttris/plugin.video.sendtokodi" ]]; then
     mv plugin.video.sendtokodi-$VERSION.zip $REPO_FOLDER/plugin.video.sendtokodi/
 
     # Update repository's addon.xml with the addon's addon.xml
-    $GITHUB_WORKSPACE/.github/scripts/update-repo-xml.py --repo-root $REPO_FOLDER
+    $GITHUB_WORKSPACE/.github/scripts/update-repo-xml.py --repo-root $REPO_FOLDER --version $VERSION
     cd $REPO_FOLDER
     md5sum addon.xml > addon.xml.md5
 

--- a/.github/scripts/update-repo-xml.py
+++ b/.github/scripts/update-repo-xml.py
@@ -7,12 +7,16 @@ import xml.etree.ElementTree as ET
 # check and parse arguments
 parser = argparse.ArgumentParser()
 parser.add_argument("--repo-root", required=True)
+parser.add_argument("--version", required=True)
 args = parser.parse_args()
 
 # get the addon's XML element
 src_filename = "addon.xml"
 src_tree = ET.parse(src_filename)
 src_element = src_tree.getroot()
+
+# update version
+src_element.set("version", args.version)
 
 # instantiate the repo's XML template
 tpl_filename = os.path.join(args.repo_root, "addon.template.xml")


### PR DESCRIPTION
This should fix #149 but I'm not entirely sure the wrong version caused the initial installation failure. Why would it? Sure, updates won't be installed if the version remains constant, but why would a fresh installation fail? Unfortunately the log doesn't contain the failed installation attempt.

Background: I assumed the [build-publish-addon](https://github.com/firsttris/plugin.video.sendtokodi/blob/master/.github/workflows/build-publish.yml) workflow runs the `build` and `publish` steps in the same working directory such that the latter already operates on an updated plugin `addon.xml`. That doesn't seem to be the case so I now set the version explicitly when instantiating the repo's `addon.xml` from the template.