### PR TITLE
Apply http headers to direct url playback

### DIFF
--- a/core/playback_selection.py
+++ b/core/playback_selection.py
@@ -1,5 +1,4 @@
-from urllib.parse import parse_qs, urlparse
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlparse, quote, urlencode
 
 
 def normalize_dash_audio_streams(dash_audio):
@@ -34,6 +33,18 @@ def collect_subtitle_urls(subtitles):
         for lang in subtitles
         for subtitle_list_entry in subtitles[lang]
     ]
+
+
+def append_headers_to_url(url, headers):
+    if not headers:
+        return url
+    parts = []
+    for key, value in headers.items():
+        if key and value:
+            parts.append("{}={}".format(quote(str(key)), quote(str(value))))
+    if parts:
+        return url + '|' + '&'.join(parts)
+    return url
 
 
 def encode_inputstream_headers(headers):

--- a/core/runtime/playback.py
+++ b/core/runtime/playback.py
@@ -6,6 +6,7 @@ import xbmcvfs
 from core import dash_builder
 from core.addon_params import build_flat_playlist_item_url, resolve_playlist_item_title
 from core.playback_selection import (
+    append_headers_to_url,
     collect_subtitle_urls,
     encode_inputstream_headers,
     find_playlist_start_index,
@@ -185,17 +186,19 @@ def create_list_item_from_video(
     if subtitles:
         list_item.setSubtitles(collect_subtitle_urls(subtitles))
 
+    # Many sites will throw a 403 unless the http headers (e.g. user agent and referer)
+    # sent when downloading a manifest and streaming match those originally sent by yt-dlp.
+    effective_headers = resolve_effective_headers(headers, result.get("http_headers"))
+
     if isa:
         list_item.setProperty("inputstream", "inputstream.adaptive")
-
-        # Many sites will throw a 403 unless the http headers (e.g. user agent and referer)
-        # sent when downloading a manifest and streaming match those originally sent by yt-dlp.
-        encoded_headers = encode_inputstream_headers(
-            resolve_effective_headers(headers, result.get("http_headers"))
-        )
+        encoded_headers = encode_inputstream_headers(effective_headers)
         if encoded_headers is not None:
             list_item.setProperty("inputstream.adaptive.manifest_headers", encoded_headers)
             list_item.setProperty("inputstream.adaptive.stream_headers", encoded_headers)
+    elif effective_headers and url and url.startswith(("http://", "https://")):
+        url = append_headers_to_url(url, effective_headers)
+        list_item.setPath(url)
 
     return list_item
 

--- a/tests/test_playback_selection.py
+++ b/tests/test_playback_selection.py
@@ -1,5 +1,8 @@
+from urllib.parse import quote
+
 from core.playback_selection import (
     analyze_formats,
+    append_headers_to_url,
     collect_subtitle_urls,
     encode_inputstream_headers,
     find_playlist_start_index,
@@ -1099,3 +1102,42 @@ def test_resolve_starting_entry_returns_entry_when_url_missing():
     entry = {"id": "local", "title": "already resolved"}
 
     assert resolve_starting_entry(entry, lambda *_args, **_kwargs: {"should": "not-run"}) == entry
+
+
+def test_append_headers_to_url_returns_url_when_headers_none():
+    result = append_headers_to_url(
+        url="https://example.com/stream.mp4",
+        headers=None
+    )
+
+    assert result == "https://example.com/stream.mp4"
+
+
+def test_append_headers_to_url_returns_url_when_headers_empty():
+    result = append_headers_to_url(
+        url="https://example.com/stream.mp4",
+        headers={}
+    )
+
+    assert result == "https://example.com/stream.mp4"
+
+
+def test_append_headers_to_url_appends_headers_correctly():
+    ua = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"
+    referer = "https://example.com"
+
+    result = append_headers_to_url(
+        url="https://example.com/stream.mp4",
+        headers={"User-Agent": ua, "Referer": referer},
+    )
+
+    assert result == "https://example.com/stream.mp4|User-Agent={}&Referer={}".format(quote(ua), quote(referer))
+
+
+def test_append_headers_to_url_preserves_url_with_query_params():
+    result = append_headers_to_url(
+        url="https://example.com/stream.mp4?token=abc",
+        headers={"User-Agent": "TestAgent"},
+    )
+
+    assert result == "https://example.com/stream.mp4?token=abc|User-Agent=TestAgent"


### PR DESCRIPTION
When playing direct URLs (non-ISA), the headers from yt-dlp (User-Agent, Referer, etc.) weren't being passed to Kodi. They were only applied to InputStream Adaptive content via inputstream.adaptive.manifest_headers/stream_headers.

This fix appends yt-dlp's http_headers to direct URL playback using Kodi's |Header=Value syntax, so Kodi sends the same headers that were used during resolution.

This fixes 403 errors for some services.